### PR TITLE
Implement ResponderFormularioActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,9 @@
         <!-- Lista de formulários para alunos -->
         <activity android:name=".ListaFormulariosAlunoActivity" />
 
+        <!-- Tela para responder formulário -->
+        <activity android:name=".ResponderFormularioActivity" />
+
         <!-- Tela de login (inicial do app) -->
         <activity
             android:name=".LoginActivity"

--- a/app/src/main/java/br/com/app/applogicando/ListaFormulariosAlunoActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/ListaFormulariosAlunoActivity.java
@@ -1,6 +1,7 @@
 package br.com.app.applogicando;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
@@ -24,6 +25,7 @@ public class ListaFormulariosAlunoActivity extends AppCompatActivity {
     private ListView listViewFormularios;
     private Button btnVoltarAluno;
     private final ArrayList<String> listaFormularios = new ArrayList<>();
+    private final ArrayList<String> listaFormulariosIds = new ArrayList<>();
     private ArrayAdapter<String> adapter;
 
     @Override
@@ -35,6 +37,13 @@ public class ListaFormulariosAlunoActivity extends AppCompatActivity {
         btnVoltarAluno = findViewById(R.id.btnVoltarAluno);
         adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, listaFormularios);
         listViewFormularios.setAdapter(adapter);
+
+        listViewFormularios.setOnItemClickListener((parent, view, position, id) -> {
+            String formularioId = listaFormulariosIds.get(position);
+            Intent intent = new Intent(this, ResponderFormularioActivity.class);
+            intent.putExtra("formularioId", formularioId);
+            startActivity(intent);
+        });
 
         btnVoltarAluno.setOnClickListener(v -> finish());
 
@@ -69,10 +78,13 @@ public class ListaFormulariosAlunoActivity extends AppCompatActivity {
                     JSONArray jsonArray = new JSONArray(response.toString());
 
                     listaFormularios.clear();
+                    listaFormulariosIds.clear();
                     for (int i = 0; i < jsonArray.length(); i++) {
                         JSONObject formulario = jsonArray.getJSONObject(i);
                         String titulo = formulario.getString("titulo");
+                        String id = formulario.getString("id");
                         listaFormularios.add(titulo);
+                        listaFormulariosIds.add(id);
                     }
 
                     runOnUiThread(() -> adapter.notifyDataSetChanged());

--- a/app/src/main/java/br/com/app/applogicando/ResponderFormularioActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/ResponderFormularioActivity.java
@@ -1,0 +1,205 @@
+package br.com.app.applogicando;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ResponderFormularioActivity extends AppCompatActivity {
+
+    private LinearLayout layoutPerguntas;
+    private Button btnEnviarRespostas;
+    private String formularioId;
+
+    private final List<Pergunta> perguntas = new ArrayList<>();
+    private final Map<String, Object> respostaViews = new HashMap<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_responder_formulario);
+
+        formularioId = getIntent().getStringExtra("formularioId");
+        if (formularioId == null || formularioId.isEmpty()) {
+            Toast.makeText(this, "ID do formulário inválido", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        layoutPerguntas = findViewById(R.id.layoutPerguntas);
+        btnEnviarRespostas = findViewById(R.id.btnEnviarRespostas);
+
+        btnEnviarRespostas.setOnClickListener(v -> enviarRespostas());
+
+        carregarPerguntas();
+    }
+
+    private void carregarPerguntas() {
+        new Thread(() -> {
+            try {
+                SharedPreferences prefs = getSharedPreferences("AppPrefs", Context.MODE_PRIVATE);
+                String token = prefs.getString("token", "");
+
+                URL url = new URL("https://logicando-api.onrender.com/perguntas/formulario/" + formularioId);
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setRequestMethod("GET");
+                conn.setRequestProperty("Authorization", "Basic " + token);
+
+                int responseCode = conn.getResponseCode();
+                if (responseCode == HttpURLConnection.HTTP_OK) {
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                    StringBuilder response = new StringBuilder();
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        response.append(line);
+                    }
+                    reader.close();
+
+                    JSONArray jsonArray = new JSONArray(response.toString());
+                    perguntas.clear();
+                    for (int i = 0; i < jsonArray.length(); i++) {
+                        JSONObject obj = jsonArray.getJSONObject(i);
+                        Pergunta p = new Pergunta();
+                        p.id = obj.getString("id");
+                        p.texto = obj.getString("texto");
+                        p.tipo = obj.getString("tipo");
+                        p.opcoes = obj.optJSONArray("opcoes");
+                        perguntas.add(p);
+                    }
+
+                    runOnUiThread(this::montarPerguntas);
+                } else {
+                    runOnUiThread(() -> Toast.makeText(this,
+                            "Erro ao carregar perguntas", Toast.LENGTH_SHORT).show());
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                runOnUiThread(() -> Toast.makeText(this,
+                        "Erro de conexão", Toast.LENGTH_SHORT).show());
+            }
+        }).start();
+    }
+
+    private void montarPerguntas() {
+        layoutPerguntas.removeAllViews();
+        for (Pergunta p : perguntas) {
+            TextView tv = new TextView(this);
+            tv.setText(p.texto);
+            tv.setTextSize(16f);
+            tv.setPadding(0, 16, 0, 8);
+            layoutPerguntas.addView(tv);
+
+            if ("MULTIPLA_ESCOLHA".equals(p.tipo) && p.opcoes != null) {
+                RadioGroup rg = new RadioGroup(this);
+                for (int i = 0; i < p.opcoes.length(); i++) {
+                    String opcao = p.opcoes.optString(i);
+                    RadioButton rb = new RadioButton(this);
+                    rb.setText(opcao);
+                    rg.addView(rb);
+                }
+                layoutPerguntas.addView(rg);
+                respostaViews.put(p.id, rg);
+            } else {
+                EditText et = new EditText(this);
+                et.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT));
+                layoutPerguntas.addView(et);
+                respostaViews.put(p.id, et);
+            }
+        }
+    }
+
+    private void enviarRespostas() {
+        new Thread(() -> {
+            try {
+                SharedPreferences prefs = getSharedPreferences("AppPrefs", Context.MODE_PRIVATE);
+                String token = prefs.getString("token", "");
+
+                JSONArray respostasArray = new JSONArray();
+                for (Pergunta p : perguntas) {
+                    String resposta = "";
+                    Object view = respostaViews.get(p.id);
+                    if (view instanceof EditText) {
+                        resposta = ((EditText) view).getText().toString().trim();
+                    } else if (view instanceof RadioGroup) {
+                        RadioGroup rg = (RadioGroup) view;
+                        int checked = rg.getCheckedRadioButtonId();
+                        if (checked != -1) {
+                            RadioButton rb = rg.findViewById(checked);
+                            resposta = rb.getText().toString();
+                        }
+                    }
+                    JSONObject respObj = new JSONObject();
+                    respObj.put("perguntaId", p.id);
+                    respObj.put("resposta", resposta);
+                    respostasArray.put(respObj);
+                }
+
+                JSONObject payload = new JSONObject();
+                payload.put("formularioId", formularioId);
+                payload.put("respostas", respostasArray);
+
+                URL url = new URL("https://logicando-api.onrender.com/respostas");
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setRequestMethod("POST");
+                conn.setRequestProperty("Content-Type", "application/json");
+                conn.setRequestProperty("Authorization", "Basic " + token);
+                conn.setDoOutput(true);
+
+                OutputStream os = conn.getOutputStream();
+                os.write(payload.toString().getBytes());
+                os.flush();
+                os.close();
+
+                int responseCode = conn.getResponseCode();
+                if (responseCode == HttpURLConnection.HTTP_OK ||
+                        responseCode == HttpURLConnection.HTTP_CREATED) {
+                    runOnUiThread(() -> {
+                        Toast.makeText(this, "Respostas enviadas com sucesso!", Toast.LENGTH_SHORT).show();
+                        Intent intent = new Intent(this, AlunoMainActivity.class);
+                        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                        startActivity(intent);
+                    });
+                } else {
+                    runOnUiThread(() -> Toast.makeText(this,
+                            "Erro ao enviar respostas", Toast.LENGTH_SHORT).show());
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                runOnUiThread(() -> Toast.makeText(this,
+                        "Erro de conexão", Toast.LENGTH_SHORT).show());
+            }
+        }).start();
+    }
+
+    private static class Pergunta {
+        String id;
+        String texto;
+        String tipo;
+        JSONArray opcoes;
+    }
+}

--- a/app/src/main/res/layout/activity_responder_formulario.xml
+++ b/app/src/main/res/layout/activity_responder_formulario.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="#FFFFFF">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:id="@+id/layoutPerguntas"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </ScrollView>
+
+    <Button
+        android:id="@+id/btnEnviarRespostas"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Enviar"
+        android:backgroundTint="#4CAF50"
+        android:textColor="#FFFFFF"
+        android:layout_marginTop="16dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add new `ResponderFormularioActivity` to allow students to answer forms
- create dynamic layout `activity_responder_formulario.xml`
- open answer screen from `ListaFormulariosAlunoActivity`
- register the new activity in the manifest

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685579f6c9f083258752bd8252b5b543