### PR TITLE
Implement VisualizarRespostasActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,9 @@
         <!-- tela ver formularios-->
         <activity android:name=".ListarFormulariosActivity" />
 
+        <!-- Tela para visualizar respostas -->
+        <activity android:name=".VisualizarRespostasActivity" />
+
         <!-- Lista de formulários para alunos -->
         <activity android:name=".ListaFormulariosAlunoActivity" />
 

--- a/app/src/main/java/br/com/app/applogicando/VisualizarRespostasActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/VisualizarRespostasActivity.java
@@ -17,49 +17,41 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 
-public class ListarFormulariosActivity extends AppCompatActivity {
+public class VisualizarRespostasActivity extends AppCompatActivity {
 
-    private ListView listViewFormularios;
-    private Button btnVoltar;
-    private final ArrayList<String> listaFormularios = new ArrayList<>();
-    private final ArrayList<String> listaFormularioIds = new ArrayList<>();
+    private ListView listViewRespostas;
+    private Button btnVoltarRespostas;
+    private final ArrayList<String> listaRespostas = new ArrayList<>();
     private ArrayAdapter<String> adapter;
 
     private String username;
     private String senha;
+    private String formularioId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_listar_formularios);
+        setContentView(R.layout.activity_visualizar_respostas);
 
-        listViewFormularios = findViewById(R.id.listViewFormularios);
-        btnVoltar = findViewById(R.id.btnVoltar);
+        listViewRespostas = findViewById(R.id.listViewRespostas);
+        btnVoltarRespostas = findViewById(R.id.btnVoltarRespostas);
 
         username = getIntent().getStringExtra("username");
         senha = getIntent().getStringExtra("senha");
+        formularioId = getIntent().getStringExtra("formularioId");
 
-        adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, listaFormularios);
-        listViewFormularios.setAdapter(adapter);
+        adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, listaRespostas);
+        listViewRespostas.setAdapter(adapter);
 
-        listViewFormularios.setOnItemClickListener((parent, view, position, id) -> {
-            String formularioId = listaFormularioIds.get(position);
-            android.content.Intent intent = new android.content.Intent(this, VisualizarRespostasActivity.class);
-            intent.putExtra("formularioId", formularioId);
-            intent.putExtra("username", username);
-            intent.putExtra("senha", senha);
-            startActivity(intent);
-        });
+        btnVoltarRespostas.setOnClickListener(v -> finish());
 
-        btnVoltar.setOnClickListener(view -> finish());
-
-        carregarFormularios();
+        carregarRespostas();
     }
 
-    private void carregarFormularios() {
+    private void carregarRespostas() {
         new Thread(() -> {
             try {
-                URL url = new URL("https://logicando-api.onrender.com/formularios");
+                URL url = new URL("https://logicando-api.onrender.com/respostas/formulario/" + formularioId);
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("GET");
 
@@ -79,21 +71,13 @@ public class ListarFormulariosActivity extends AppCompatActivity {
 
                     JSONArray jsonArray = new JSONArray(response.toString());
 
-                    listaFormularios.clear();
-                    listaFormularioIds.clear();
+                    listaRespostas.clear();
                     for (int i = 0; i < jsonArray.length(); i++) {
-                        JSONObject formulario = jsonArray.getJSONObject(i);
-                        String id = formulario.optString("id");
-                        String titulo = formulario.getString("titulo");
-                        String criador = formulario.getString("criadorNome");
-                        String criadoEm = formulario.getString("criadoEm");
-
-                        listaFormularioIds.add(id);
-                        listaFormularios.add(titulo + "\nCriado por: " + criador + "\nEm: " + criadoEm);
+                        JSONObject resposta = jsonArray.getJSONObject(i);
+                        listaRespostas.add(resposta.toString());
                     }
 
                     runOnUiThread(() -> adapter.notifyDataSetChanged());
-
                 } else {
                     BufferedReader errorReader = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
                     StringBuilder errorResponse = new StringBuilder();
@@ -103,7 +87,7 @@ public class ListarFormulariosActivity extends AppCompatActivity {
                     }
                     errorReader.close();
 
-                    String errorMsg = "Erro ao buscar formulários.\nCódigo: " + responseCode +
+                    String errorMsg = "Erro ao buscar respostas.\nCódigo: " + responseCode +
                             "\nMensagem: " + errorResponse.toString();
 
                     runOnUiThread(() -> Toast.makeText(this, errorMsg, Toast.LENGTH_LONG).show());
@@ -117,3 +101,4 @@ public class ListarFormulariosActivity extends AppCompatActivity {
         }).start();
     }
 }
+

--- a/app/src/main/res/layout/activity_visualizar_respostas.xml
+++ b/app/src/main/res/layout/activity_visualizar_respostas.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="#FFFFFF">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Respostas"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:layout_marginBottom="16dp"/>
+
+    <ListView
+        android:id="@+id/listViewRespostas"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:divider="#CCCCCC"
+        android:dividerHeight="1dp"/>
+
+    <Button
+        android:id="@+id/btnVoltarRespostas"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Voltar"
+        android:backgroundTint="#F44336"
+        android:textColor="#FFFFFF"
+        android:layout_marginTop="16dp"/>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add activity and layout to visualize form responses
- open `VisualizarRespostasActivity` when a form is tapped
- pass form ID, username and password between activities
- list responses from `GET /respostas/formulario/{formularioId}`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685579f9317c832596b250a013d23a38