### PR TITLE
Add ApiConfig for network base and update activities

### DIFF
--- a/app/src/main/java/br/com/app/applogicando/ApiConfig.java
+++ b/app/src/main/java/br/com/app/applogicando/ApiConfig.java
@@ -1,0 +1,11 @@
+package br.com.app.applogicando;
+
+import android.util.Base64;
+
+public class ApiConfig {
+    public static final String BASE_URL = "https://logicando-api.onrender.com";
+
+    public static String buildBasicAuthHeader(String username, String password) {
+        return "Basic " + Base64.encodeToString((username + ":" + password).getBytes(), Base64.NO_WRAP);
+    }
+}

--- a/app/src/main/java/br/com/app/applogicando/CadastroActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/CadastroActivity.java
@@ -16,6 +16,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import br.com.app.applogicando.ApiConfig;
+
 public class CadastroActivity extends AppCompatActivity {
 
     EditText editNome, editUsernameCadastro, editSenhaCadastro;
@@ -52,7 +54,7 @@ public class CadastroActivity extends AppCompatActivity {
     private void cadastrarUsuario(String nome, String username, String senha, String papel) {
         new Thread(() -> {
             try {
-                URL url = new URL("https://logicando-api.onrender.com/usuarios");
+                URL url = new URL(ApiConfig.BASE_URL + "/usuarios");
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("POST");
                 conn.setRequestProperty("Content-Type", "application/json");

--- a/app/src/main/java/br/com/app/applogicando/CriarFormularioActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/CriarFormularioActivity.java
@@ -18,6 +18,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Scanner;
 
+import br.com.app.applogicando.ApiConfig;
+
 public class CriarFormularioActivity extends AppCompatActivity {
 
     EditText editTituloFormulario;
@@ -55,7 +57,7 @@ public class CriarFormularioActivity extends AppCompatActivity {
     private void criarFormulario(String titulo, String token) {
         new Thread(() -> {
             try {
-                URL url = new URL("https://logicando-api.onrender.com/formularios");
+                URL url = new URL(ApiConfig.BASE_URL + "/formularios");
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("POST");
                 conn.setRequestProperty("Content-Type", "application/json");

--- a/app/src/main/java/br/com/app/applogicando/CriarPerguntaActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/CriarPerguntaActivity.java
@@ -19,6 +19,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import br.com.app.applogicando.ApiConfig;
+
 public class CriarPerguntaActivity extends AppCompatActivity {
 
     EditText editTextoPergunta;
@@ -95,7 +97,7 @@ public class CriarPerguntaActivity extends AppCompatActivity {
     private void adicionarPergunta(String formularioId, String texto, String tipo, String token, JSONArray opcoes) {
         new Thread(() -> {
             try {
-                URL url = new URL("https://logicando-api.onrender.com/perguntas");
+                URL url = new URL(ApiConfig.BASE_URL + "/perguntas");
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("POST");
                 conn.setRequestProperty("Content-Type", "application/json");

--- a/app/src/main/java/br/com/app/applogicando/ListaFormulariosAlunoActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/ListaFormulariosAlunoActivity.java
@@ -19,6 +19,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 
+import br.com.app.applogicando.ApiConfig;
+
 public class ListaFormulariosAlunoActivity extends AppCompatActivity {
 
     private ListView listViewFormularios;
@@ -48,12 +50,11 @@ public class ListaFormulariosAlunoActivity extends AppCompatActivity {
                 String username = prefs.getString("username", "");
                 String senha = prefs.getString("senha", "");
 
-                URL url = new URL("https://logicando-api.onrender.com/formularios");
+                URL url = new URL(ApiConfig.BASE_URL + "/formularios");
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("GET");
 
-                String basicAuth = "Basic " + android.util.Base64.encodeToString(
-                        (username + ":" + senha).getBytes(), android.util.Base64.NO_WRAP);
+                String basicAuth = ApiConfig.buildBasicAuthHeader(username, senha);
                 conn.setRequestProperty("Authorization", basicAuth);
 
                 int responseCode = conn.getResponseCode();

--- a/app/src/main/java/br/com/app/applogicando/ListarFormulariosActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/ListarFormulariosActivity.java
@@ -17,6 +17,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 
+import br.com.app.applogicando.ApiConfig;
+
 public class ListarFormulariosActivity extends AppCompatActivity {
 
     private ListView listViewFormularios;
@@ -49,12 +51,11 @@ public class ListarFormulariosActivity extends AppCompatActivity {
     private void carregarFormularios() {
         new Thread(() -> {
             try {
-                URL url = new URL("https://logicando-api.onrender.com/formularios");
+                URL url = new URL(ApiConfig.BASE_URL + "/formularios");
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("GET");
 
-                String basicAuth = "Basic " + android.util.Base64.encodeToString(
-                        (username + ":" + senha).getBytes(), android.util.Base64.NO_WRAP);
+                String basicAuth = ApiConfig.buildBasicAuthHeader(username, senha);
                 conn.setRequestProperty("Authorization", basicAuth);
 
                 int responseCode = conn.getResponseCode();

--- a/app/src/main/java/br/com/app/applogicando/LoginActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/LoginActivity.java
@@ -5,6 +5,8 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Base64;
+
+import br.com.app.applogicando.ApiConfig;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -57,7 +59,7 @@ public class LoginActivity extends AppCompatActivity {
     private void autenticarUsuario(String username, String senha, String token) {
         new Thread(() -> {
             try {
-                URL url = new URL("https://logicando-api.onrender.com/usuarios");
+                URL url = new URL(ApiConfig.BASE_URL + "/usuarios");
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("GET");
                 conn.setRequestProperty("Authorization", "Basic " + token);


### PR DESCRIPTION
## Summary
- introduce `ApiConfig` with a `BASE_URL` constant and a helper for basic auth header
- refactor activities to build URLs from `ApiConfig.BASE_URL`
- use the helper when creating Basic auth headers

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685579fcadcc8325af7b91841e80ba1e