### PR TITLE
Fix cred retrieval for listing/responses

### DIFF
--- a/app/src/main/java/br/com/app/applogicando/ListarFormulariosActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/ListarFormulariosActivity.java
@@ -1,5 +1,7 @@
 package br.com.app.applogicando;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -41,15 +43,27 @@ public class ListarFormulariosActivity extends AppCompatActivity {
         username = getIntent().getStringExtra("username");
         senha = getIntent().getStringExtra("senha");
 
+        if (username == null || username.isEmpty() || senha == null || senha.isEmpty()) {
+            SharedPreferences prefs = getSharedPreferences("AppPrefs", Context.MODE_PRIVATE);
+            if (username == null || username.isEmpty()) {
+                username = prefs.getString("username", "");
+            }
+            if (senha == null || senha.isEmpty()) {
+                senha = prefs.getString("senha", "");
+            }
+        }
+
         adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, listaFormularios);
         listViewFormularios.setAdapter(adapter);
 
         listViewFormularios.setOnItemClickListener((parent, view, position, id) -> {
             String formularioId = listaFormularioIds.get(position);
             android.content.Intent intent = new android.content.Intent(this, VisualizarRespostasActivity.class);
+            android.os.Bundle extras = getIntent().getExtras();
+            if (extras != null) {
+                intent.putExtras(extras);
+            }
             intent.putExtra("formularioId", formularioId);
-            intent.putExtra("username", username);
-            intent.putExtra("senha", senha);
             startActivity(intent);
         });
 

--- a/app/src/main/java/br/com/app/applogicando/VisualizarRespostasActivity.java
+++ b/app/src/main/java/br/com/app/applogicando/VisualizarRespostasActivity.java
@@ -1,5 +1,7 @@
 package br.com.app.applogicando;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -16,6 +18,8 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
+
+import br.com.app.applogicando.ApiConfig;
 
 public class VisualizarRespostasActivity extends AppCompatActivity {
 
@@ -40,6 +44,16 @@ public class VisualizarRespostasActivity extends AppCompatActivity {
         senha = getIntent().getStringExtra("senha");
         formularioId = getIntent().getStringExtra("formularioId");
 
+        if (username == null || username.isEmpty() || senha == null || senha.isEmpty()) {
+            SharedPreferences prefs = getSharedPreferences("AppPrefs", Context.MODE_PRIVATE);
+            if (username == null || username.isEmpty()) {
+                username = prefs.getString("username", "");
+            }
+            if (senha == null || senha.isEmpty()) {
+                senha = prefs.getString("senha", "");
+            }
+        }
+
         adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, listaRespostas);
         listViewRespostas.setAdapter(adapter);
 
@@ -55,8 +69,7 @@ public class VisualizarRespostasActivity extends AppCompatActivity {
                 HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("GET");
 
-                String basicAuth = "Basic " + android.util.Base64.encodeToString(
-                        (username + ":" + senha).getBytes(), android.util.Base64.NO_WRAP);
+                String basicAuth = ApiConfig.buildBasicAuthHeader(username, senha);
                 conn.setRequestProperty("Authorization", basicAuth);
 
                 int responseCode = conn.getResponseCode();


### PR DESCRIPTION
## Summary
- load saved credentials in `ListarFormulariosActivity`
- copy existing extras when launching `VisualizarRespostasActivity`
- add same credentials fallback in `VisualizarRespostasActivity`
- use `ApiConfig` helper to build authorization header

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685af8b64a4883259a1b8121319e4a4b